### PR TITLE
fix: guard null modul and add loading skeletons on /monitor

### DIFF
--- a/src/app/(authenticated)/monitoring/components/monitoring-journal-client.tsx
+++ b/src/app/(authenticated)/monitoring/components/monitoring-journal-client.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/table";
 import ViewSwitcher from "@/components/ui/view-switcher";
 import { useMonitorJournalQuery } from "@/queries/useMonitorJournalQuery";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { Journal } from "@/types/monitor";
 
 export default function MonitoringJournalClient() {
@@ -29,7 +30,7 @@ export default function MonitoringJournalClient() {
 	const { data, isLoading, error } = todayJournalQuery;
 
 	if (isLoading) {
-		return <div className="py-8 text-center">Memuat data jurnal...</div>;
+		return <MonitoringJournalSkeleton view={view} />;
 	}
 
 	if (error) {
@@ -64,6 +65,46 @@ export default function MonitoringJournalClient() {
 	);
 }
 
+// Skeleton untuk kondisi pemuatan data jurnal
+function MonitoringJournalSkeleton({ view }: { view: "table" | "grid" }) {
+	return (
+		<Card>
+			<CardHeader className="flex flex-row justify-between items-center">
+				<div className="space-y-2">
+					<Skeleton className="w-48 h-6" />
+					<Skeleton className="w-64 h-4" />
+				</div>
+				<Skeleton className="w-24 h-8" />
+			</CardHeader>
+			<CardContent>
+				{view === "table" ? (
+					<div className="space-y-2">
+						<Skeleton className="w-full h-10" />
+						{Array.from({ length: 6 }).map((_, i) => (
+							<Skeleton key={i} className="w-full h-12" />
+						))}
+					</div>
+				) : (
+					<div className="gap-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+						{Array.from({ length: 6 }).map((_, i) => (
+							<Card key={i}>
+								<CardHeader>
+									<Skeleton className="w-32 h-5" />
+									<Skeleton className="mt-1 w-24 h-4" />
+								</CardHeader>
+								<CardContent className="space-y-2">
+									<Skeleton className="w-2/3 h-4" />
+									<Skeleton className="w-1/2 h-4" />
+								</CardContent>
+							</Card>
+						))}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
 function JournalTable({ data }: { data: Journal[] }) {
 	return (
 		<Table>
@@ -95,19 +136,19 @@ function JournalRow({ journal }: { journal: Journal }) {
 	return (
 		<TableRow>
 			<TableCell>
-				<div className="font-medium">{journal.modul.teacher.fullname}</div>
+				<div className="font-medium">{journal.modul?.teacher.fullname}</div>
 				<div className="text-muted-foreground text-sm">
-					{journal.modul.teacher.niy}
+					{journal.modul?.teacher.niy}
 				</div>
 			</TableCell>
 			<TableCell
 				className="hover:underline cursor-pointer"
 				onClick={handleNavigate}
 			>
-				{journal.modul.mapel.nama}
+				{journal.modul?.mapel.nama}
 				<ExternalLink className="inline-block ml-2 w-3 h-3 text-blue-700" />
 			</TableCell>
-			<TableCell>{journal.modul.rombel.nama}</TableCell>
+			<TableCell>{journal.modul?.rombel.nama}</TableCell>
 			<TableCell>
 				{journal.start_time} - {journal.end_time}
 			</TableCell>
@@ -146,14 +187,14 @@ function JournalGrid({ data }: { data: Journal[] }) {
 					onClick={() => router.push(`/rekap/presensi/${journal.uuid}`)}
 				>
 					<CardHeader>
-						<CardTitle>{journal.modul.mapel.nama}</CardTitle>
-						<CardDescription>{journal.modul.rombel.nama}</CardDescription>
+						<CardTitle>{journal.modul?.mapel.nama}</CardTitle>
+						<CardDescription>{journal.modul?.rombel.nama}</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-2">
 						<div>
-							<p className="font-medium">{journal.modul.teacher.fullname}</p>
+							<p className="font-medium">{journal.modul?.teacher.fullname}</p>
 							<p className="text-muted-foreground text-sm">
-								{journal.modul.teacher.niy}
+								{journal.modul?.teacher.niy}
 							</p>
 						</div>
 						<p>

--- a/src/app/(authenticated)/monitoring/components/monitoring-presence-client.tsx
+++ b/src/app/(authenticated)/monitoring/components/monitoring-presence-client.tsx
@@ -16,6 +16,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { useMonitorPresenceQuery } from "@/queries/useMonitorPresenceQuery";
+import { Skeleton } from "@/components/ui/skeleton";
 import type {
 	ActivePresence,
 	AttendanceRecord,
@@ -55,7 +56,7 @@ export default function MonitoringPresenceClient() {
 		.sort((a, b) => a - b);
 
 	if (isLoading) {
-		return <div className="py-8 text-center">Memuat data pemantauan...</div>;
+		return <MonitoringPresenceSkeleton />;
 	}
 
 	if (error) {
@@ -93,6 +94,43 @@ export default function MonitoringPresenceClient() {
 					<div className="gap-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
 						{groupedRombels[grade].map((rombel) => (
 							<RombelCard key={rombel.id} rombel={rombel} />
+						))}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+// Skeleton untuk kondisi pemuatan data pemantauan
+function MonitoringPresenceSkeleton() {
+	const grades = [7, 8, 9];
+	return (
+		<div className="space-y-6">
+			<div className="flex justify-between items-center bg-muted p-4 rounded-lg">
+				<Skeleton className="w-48 h-5" />
+				<div className="flex gap-4">
+					<Skeleton className="w-24 h-6" />
+					<Skeleton className="w-24 h-6" />
+				</div>
+			</div>
+			{grades.map((grade) => (
+				<div key={grade} className="space-y-4">
+					<Skeleton className="w-24 h-7" />
+					<div className="gap-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+						{Array.from({ length: 3 }).map((_, i) => (
+							<Card key={i}>
+								<CardHeader className="pb-2">
+									<Skeleton className="w-32 h-5" />
+									<Skeleton className="mt-1 w-24 h-4" />
+								</CardHeader>
+								<CardContent className="space-y-2">
+									<Skeleton className="w-full h-4" />
+									<Skeleton className="w-2/3 h-4" />
+									<Skeleton className="w-1/2 h-4" />
+									<Skeleton className="mt-2 w-full h-10" />
+								</CardContent>
+							</Card>
 						))}
 					</div>
 				</div>
@@ -155,12 +193,12 @@ function RombelCard({ rombel }: { rombel: RombelWithPresence }) {
 						<div className="flex items-center gap-2">
 							<BookOpen className="w-4 h-4 text-muted-foreground" />
 							<span className="font-medium">
-								{rombel.presence?.modul.mapel.nama}
+								{rombel.presence?.modul?.mapel.nama}
 							</span>
 						</div>
 						<div className="flex items-center gap-2">
 							<User className="w-4 h-4 text-muted-foreground" />
-							<span>{rombel.presence?.modul.teacher.fullname}</span>
+							<span>{rombel.presence?.modul?.teacher.fullname}</span>
 						</div>
 						<div className="flex items-center gap-2">
 							<CalendarClock className="w-4 h-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- Fix crash `Cannot read properties of null (reading 'teacher')` on /monitor by guarding `modul` (which can be null at runtime) before accessing `modul.teacher` / `modul.mapel` in both presence and journal clients.
- Replace plain `Memuat..." text with Skeleton-based loaders matching each tab's layout (presence grid of cards, journal table/grid).

## Test plan
- Visit /monitor (Presensi tab) with data where presence exists but modul is null — no crash.
- Switch to Jurnal Guru tab and observe skeleton during loading.